### PR TITLE
Ver.3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,143 +7,108 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 * workspace counter in status bar.
 
-## [3.2.0]
-
+## [3.3.0]
 ### Changed
+- Change the line counting method [#96](https://github.com/uctakeoff/vscode-counter/issues/96).
+  - In line with the POSIX definition of lines in text files, lines that do not end with a newline (i.e., the last line) are not included in the count.However, the default setting is the same as before to avoid confusion.
 
+## [3.2.2]
+### Fixed
+- Fixed Issue [#93](https://github.com/uctakeoff/vscode-counter/issues/93).
+
+## [3.2.1]
+### Fixed
+- Added spaces in statusbar
+
+## [3.2.0]
+### Changed
 - Count the files in the top-level as a separate item #81
 
 ## [3.1.0]
-
 ### Changed
-
 - Support storing collected language elsewhere #78
+
 ## [3.0.0]
-
 ### Changed
-
 - Reviewed file detection rules
 
 ## [2.4.0]
-
 ### Added
-
 - Counter diff output function
-
 ### Changed
-
 - Moved the status bar to the right
-
 ### Removed
-
 - Disuse Configuration : `VSCodeCounter.outputMarkdownSeparately`.
 
 ## [2.3.0]
-
 ### Fixed
-
 - Error on large code bases
 
 ## [2.2.2]
-
 ### Fixed
-
 - Fixed Issue [#48](https://github.com/uctakeoff/vscode-counter/issues/48).
 
 ## [2.2.1]
-
 ### Fixed
-
 - Misconceptions about FileStat.
 
 ## [2.2.0]
-
 ### Added
-
 - New Configuration : `VSCodeCounter.history`.
 
 ## [2.1.0]
-
 ### Added
-
 - New Function : Count the range of the selected text.
 
 ## [2.0.0]
-
 ### Added
-
 - New Command : `Save the collected language configurations`.
-
 ### Update
-
 - This extension is no longer resident.
   - Don't save whether or not the program is shown in the status bar in the settings.
 
 ## [1.3.5]
-
 ### Fixed
-
 - Issue : `CSV could be more strictly formed`.
 
 ## [1.3.4]
-
 ### Fixed
-
 - Issue : `Handling symlinks`.
 
 ## [1.3.3]
-
 ### Added
-
 - New Command : `Check available languages`.
 
 ## [1.3.2]
-
 ### Fixed
-
 - Replaced the file API used with one provided by vscode.
 
 ## [1.3.1]
-
 ### Fixed
-
 - Problems that occur when `files.encoding` is set to a value other than utf8
 
 ## [1.3.0]
-
 ### Added
-
 - Support Multi-root Workspaces. (Selection type)
 
-
 ## [1.2.1]
-
 ### Fixed
-
 - Update some modules.
 
 ## [1.2.0]
-
 ### Changed
-
 - Output Markdown summary and details separately. (selectable by settings.json)
 
-
 ## [1.1.1]
-
 ### Added
-
 - resolve file types using ["files.associations"](https://code.visualstudio.com/docs/languages/overview#_adding-a-file-extension-to-a-language) setting.
-
 
 ## [1.0.1]
 ### Fixed
-
 - Error on large code bases
 
 ## [1.0.0]
 ### Fixed
-
 - Auto ignore the .VSCodeCounter directory.
 
 ## [0.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 - Change the line counting method [#96](https://github.com/uctakeoff/vscode-counter/issues/96).
   - In line with the POSIX definition of lines in text files, lines that do not end with a newline (i.e., the last line) are not included in the count.However, the default setting is the same as before to avoid confusion.
+- Enable the real-time counter at start-up.
+  - However, it should not be resident.
 
 ## [3.2.2]
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-counter",
   "displayName": "VS Code Counter",
   "description": "Count lines of code in many programming languages.",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "publisher": "uctakeoff",
   "author": {
     "name": "Ushiyama Kentaro"
@@ -107,6 +107,11 @@
         },
         "VSCodeCounter.printNumberWithCommas": {
           "description": "%configuration.printNumberWithCommas.description%",
+          "type": "boolean",
+          "default": true
+        },
+        "VSCodeCounter.includeIncompleteLine": {
+          "description": "%configuration.includeIncompleteLine.description%",
           "type": "boolean",
           "default": true
         },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "line"
   ],
   "activationEvents": [
+    "workspaceContains:**/.VSCodeCounterCountRealtime",
     "onCommand:extension.vscode-counter.countInFile",
     "onCommand:extension.vscode-counter.countInDirectory",
     "onCommand:extension.vscode-counter.countInWorkspace",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -10,6 +10,7 @@
   "configuration.maxOpenFiles.description": "VSCodeCounter が同時に読み取ることのできるファイルの最大数.",
   "configuration.printNumberWithCommas.description": "数値をカンマ区切りで出力する (CSVを除く).",
   "configuration.ignoreUnsupportedFile.description": "サポートしないファイルを無視する.",
+  "configuration.includeIncompleteLine.description": "改行で終わらない行(最終行)を含める.",
   "configuration.endOfLine.description": "出力ファイルで使用する改行文字.",
   "configuration.exclude.description": "ファイルとフォルダーを除外するための glob パターン.",
   "configuration.include.description": "ファイルとフォルダーを追加するための glob パターン.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,6 +10,7 @@
   "configuration.maxOpenFiles.description": "Maximum number of files that VSCodeCounter can read simultaneously.",
   "configuration.printNumberWithCommas.description": "Whether to print a number with commas as thousands separators.(except for CSV)",
   "configuration.ignoreUnsupportedFile.description": "Ignore unsupported files.",
+  "configuration.includeIncompleteLine.description": "Include lines that do not end in a newline (last line).",
   "configuration.endOfLine.description": "A new line character to be used in the output file.",
   "configuration.exclude.description": "Configure glob patterns for excluding files and folders.",
   "configuration.include.description": "Configure glob patterns for including files and folders.",

--- a/src/LineCounter.ts
+++ b/src/LineCounter.ts
@@ -50,14 +50,18 @@ export class LineCounter {
         private lineComments: string[],
         private blockComments: [string, string][],
         private blockStrings: [string, string][]) {
-            this.blockCommentBegins = this.blockComments.map(b => b[0]);
-            this.blockStringBegins = this.blockStrings.map(b => b[0]);
+        this.blockCommentBegins = this.blockComments.map(b => b[0]);
+        this.blockStringBegins = this.blockStrings.map(b => b[0]);
     }
-    public count(text: string): Count {
+    public count(text: string, includeIncompleteLine = false): Count {
         let result = [0, 0, 0];
         let blockCommentEnd = '';
         let blockStringEnd = '';
-        text.split(/\r\n|\r|\n/).map(line => line.trim()).forEach((line, lineIndex) => {
+        const lines = text.split(/\r\n|\r|\n/).map(line => line.trim());
+        if (!includeIncompleteLine) {
+            lines.pop();
+        }
+        lines.forEach((line, lineIndex) => {
             let type = (blockCommentEnd.length > 0) ? LineType.Comment : (blockStringEnd.length > 0) ? LineType.Code : LineType.Blank;
             let i = 0;
             while (i < line.length) {

--- a/src/vscode-utils.ts
+++ b/src/vscode-utils.ts
@@ -159,8 +159,10 @@ export const showTextPreview = async (uri: vscode.Uri) => {
         await showTextFile(uri);
     }
 }
-export const writeTextFile = async (baseUri: vscode.Uri, path: string | undefined, text: string) => {
-    const uri = path ? buildUri(baseUri, path) : baseUri;
+export const writeTextFile = async (uri: vscode.Uri, text: string, option?: {recursive?: boolean}) => {
+    if (option?.recursive) {
+        await makeDirectories(dirUri(uri));
+    }
     // log(`writeTextFile : ${uri} ${text.length}B`);
     await vscode.workspace.fs.writeFile(uri, encoderU8.encode(text));
     return uri;


### PR DESCRIPTION
### Changed
- Change the line counting method [#96](https://github.com/uctakeoff/vscode-counter/issues/96).
  - In line with the POSIX definition of lines in text files, lines that do not end with a newline (i.e., the last line) are not included in the count.However, the default setting is the same as before to avoid confusion.
- Enable the real-time counter at start-up.
  - However, it should not be resident.
